### PR TITLE
remove with_rate_limit from public api

### DIFF
--- a/langchain_benchmarks/__init__.py
+++ b/langchain_benchmarks/__init__.py
@@ -1,5 +1,5 @@
 from langchain_benchmarks.model_registration import model_registry
-from langchain_benchmarks.rate_limiting import RateLimiter, with_rate_limit
+from langchain_benchmarks.rate_limiting import RateLimiter
 from langchain_benchmarks.registration import registry
 from langchain_benchmarks.utils._langsmith import (
     clone_public_dataset,
@@ -13,5 +13,4 @@ __all__ = [
     "model_registry",
     "RateLimiter",
     "registry",
-    "with_rate_limit",
 ]

--- a/langchain_benchmarks/tool_usage/agents.py
+++ b/langchain_benchmarks/tool_usage/agents.py
@@ -9,7 +9,7 @@ from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain.schema.runnable import Runnable, RunnableLambda, RunnablePassthrough
 from langchain.tools.render import format_tool_to_openai_function
 
-from langchain_benchmarks import rate_limiting, with_rate_limit
+from langchain_benchmarks import rate_limiting
 from langchain_benchmarks.schema import ToolUsageTask
 
 

--- a/tests/unit_tests/test_public_api.py
+++ b/tests/unit_tests/test_public_api.py
@@ -12,7 +12,6 @@ def test_public_api() -> None:
             "model_registry",
             "RateLimiter",
             "registry",
-            "with_rate_limit",
         ],
         key=lambda x: x.lower(),
     )


### PR DESCRIPTION
Because it's not a runnable binding it breaks things like .bind etc, let's use
it internally but not expose to users
