### PR TITLE
Missing Word in comparing_techniques.ipynb

### DIFF
--- a/docs/source/notebooks/retrieval/comparing_techniques.ipynb
+++ b/docs/source/notebooks/retrieval/comparing_techniques.ipynb
@@ -311,7 +311,7 @@
     "\n",
     "## Customizing Chunking\n",
     "\n",
-    "The simplest change you can make to the index is configure how you split the "
+    "The simplest change you can make to the index is configure how you split the documents."
    ]
   },
   {


### PR DESCRIPTION
Fixing a missing word in https://langchain-ai.github.io/langchain-benchmarks/notebooks/retrieval/comparing_techniques.html

The sentence after the heading is incomplete since I have added the word `documents` which would complete the sentence.

Before changing:
<img width="527" alt="LangChainFix" src="https://github.com/langchain-ai/langchain-benchmarks/assets/63769209/4859bbf0-19ae-4b87-830d-85f6242b9b61">
